### PR TITLE
fix: remove data.attrs.to before return

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ const vueLinkFactory = (slashes, isNuxt) => ({
     const linkComponent = isNuxt ? 'NuxtLink' : 'RouterLink'
 
     const defaultSlots = slots().default
-
+    delete data.attrs.to // removing because the to attribute is rendered on the frontend!
     return isLinkedToExternal
       ? h('a', {
         ...data,


### PR DESCRIPTION
Expected result is for the 'to' prop to be removed before rendering on frontend in order to stop HTML validation errors (Attribute to not allowed on element a at this point).
